### PR TITLE
actually Trigger an upstream-response-validation-error in the tutorial

### DIFF
--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -885,7 +885,7 @@ HTTP/1.1 400 Bad Request
 …
 Error-Code: 3202
 …
-{"CustomError":{"Message":"Upstream Request Validation Failed","Info":["Pattern constraint violated in query for q: 'hello repo:leachim6\/hello-world filename:html lang:html' does not match the pattern '^hello repo:leachim6\/hello-world filename:\\w+ language:\\w+$'."]
+{"CustomError":{"Message":"Upstream Request Validation Failed","Info":["Pattern constraint violated in query for q: 'hello repo:leachim6\/hello-world filename:html lang:html' does not match the pattern '^hello repo:leachim6\/hello-world filename:\\w+ language:\\w+$'."]}}
 ```
 
 Now revert the change to `upstream_request.xml`:

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -1192,3 +1192,24 @@ paths:
               items:
                 type: array
 ```
+
+### `error.xml`
+
+```xml
+<flow>
+  <template>
+    {
+      "CustomError":  {
+        "Message": {{ $error/message }},
+        "Info": {{ $error/info }}
+      }
+    }
+  </template>
+  <set-response-headers>
+    {
+      "Status": {{ $error/status }},
+      "Error-Code": {{ $error/code }}
+    }
+  </set-response-headers>
+</flow>
+```

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -885,7 +885,7 @@ HTTP/1.1 400 Bad Request
 …
 Error-Code: 3202
 …
-{"CustomError":{"Message":"Upstream Request Validation Failed","Info":["Pattern constraint violated in query for q: 'hello repo:leachim6\/hello-world filename:html lang:html' does not match the pattern '^hello repo:leachim6\/hello-world filename:\\w+ language:\\w+$'."]}}
+{"CustomError":{"Message":"Upstream Request Validation Failed","Info":["Pattern constraint violated in query for q: 'hello repo:leachim6\/hello filename:html language:html' does not match the pattern '^hello repo:leachim6\/hello-world filename:\\w+ language:\\w+$'."]}}
 ```
 
 Now revert the change to `upstream_request.xml`:

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -815,12 +815,13 @@ To abort the flow in case the upstream request or response is invalid or the req
   </request>
 ```
 
-To see the effect, change the parameter name `language` to `lang` in upstream_request.xml:
+To see the effect, shorten the `hello-world` of the repository name to just `hello` in upstream_request.xml:
 
 ```xml
       …
-      {{ concat("lang:", $request/params/language) }}
-      <!--       ⬆ ⬆ ⬆ -->
+      "repo:leachim6/hello",
+      <!--              ⬆ ⬆ ⬆ -->
+      …
     ]
   </template>
 ```
@@ -847,7 +848,7 @@ HTTP/1.1 400 Bad Request
 …
 ```
 ```json
-{"error":{"message":"Upstream Request Validation Failed","status":400,"requestID":"main","info":["Pattern constraint violated in query for q: 'hello repo:leachim6\/hello-world filename:html lang:html' does not match the pattern '^hello repo:leachim6\/hello-world filename:\\w+ language:\\w+$'."],"code":3202}}
+{"error":{"message":"Upstream Response Validation Failed","status":502,"requestID":"main","info":["No definition for status code 422 and no 'default'.","Upstream status: 422 Unprocessable Entity"],"code":3203}}
 ```
 
 If you prefer to provide a custom error document, you can configure an error flow. Just create `error.xml`:
@@ -889,15 +890,16 @@ Error-Code: 3202
 …
 ```
 ```json
-{"CustomError":{"Message":"Upstream Request Validation Failed","Info":["Pattern constraint violated in query for q: 'hello repo:leachim6\/hello-world filename:html lang:html' does not match the pattern '^hello repo:leachim6\/hello-world filename:\\w+ language:\\w+$'."]}}
+{"CustomError":{"Message":"Upstream Request Validation Failed","Info":["Pattern constraint violated in query for q: 'hello repo:leachim6\/hello-world filename:html lang:html' does not match the pattern '^hello repo:leachim6\/hello-world filename:\\w+ language:\\w+$'."]
 ```
 
 Now revert the change to upstream_request.xml:
 
 ```xml
       …
-      {{ concat("language:", $request/params/language) }}
-      <!--       ⬆ ⬆ ⬆ -->
+      "repo:leachim6/hello-world",
+      <!--              ⬆ ⬆ ⬆ -->
+      …
     ]
   </template>
 ```

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -818,12 +818,12 @@ To abort the flow in case the upstream request or response is invalid or the req
 To see the effect, shorten the `hello-world` of the repository name to just `hello` in `upstream_request.xml`:
 
 ```xml
-      …
+    …
+    [
+      "q=hello",
       "repo:leachim6/hello",
       <!--              ⬆ ⬆ ⬆ -->
       …
-    ]
-  </template>
 ```
 
 If we request our API
@@ -891,12 +891,12 @@ Error-Code: 3202
 Now revert the change to `upstream_request.xml`:
 
 ```xml
-      …
+    …
+    [
+      "q=hello",
       "repo:leachim6/hello-world",
       <!--              ⬆ ⬆ ⬆ -->
       …
-    ]
-  </template>
 ```
 
 

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -815,7 +815,7 @@ To abort the flow in case the upstream request or response is invalid or the req
   </request>
 ```
 
-To see the effect, shorten the `hello-world` of the repository name to just `hello` in upstream_request.xml:
+To see the effect, shorten the `hello-world` of the repository name to just `hello` in `upstream_request.xml`:
 
 ```xml
       …
@@ -827,8 +827,9 @@ To see the effect, shorten the `hello-world` of the repository name to just `hel
 ```
 
 If we request our API
-```
-curl -si localhost:8080/html
+
+```bash
+$ curl -si localhost:8080/html
 ```
 
 instead of the output
@@ -836,8 +837,6 @@ instead of the output
 ```
 HTTP/1.1 404 Not Found
 …
-```
-```
 {"error": "Unknown language"}
 ```
 
@@ -846,8 +845,6 @@ we now get
 ```
 HTTP/1.1 400 Bad Request
 …
-```
-```json
 {"error":{"message":"Upstream Response Validation Failed","status":502,"requestID":"main","info":["No definition for status code 422 and no 'default'.","Upstream status: 422 Unprocessable Entity"],"code":3203}}
 ```
 
@@ -888,12 +885,10 @@ HTTP/1.1 400 Bad Request
 …
 Error-Code: 3202
 …
-```
-```json
 {"CustomError":{"Message":"Upstream Request Validation Failed","Info":["Pattern constraint violated in query for q: 'hello repo:leachim6\/hello-world filename:html lang:html' does not match the pattern '^hello repo:leachim6\/hello-world filename:\\w+ language:\\w+$'."]
 ```
 
-Now revert the change to upstream_request.xml:
+Now revert the change to `upstream_request.xml`:
 
 ```xml
       …


### PR DESCRIPTION
github seems to always provide a "valid" json response for basically anything in the correct repo. Just request something entirely different to check validation errors.